### PR TITLE
Departments duplication patch

### DIFF
--- a/ND_CharacterSelection/fxmanifest.lua
+++ b/ND_CharacterSelection/fxmanifest.lua
@@ -2,7 +2,7 @@
 
 author "Andyyy#7666, N1K0#0001"
 description "ND Character Selection (DOJ Based)"
-version "2.2.1"
+version "2.2.2"
 
 fx_version "cerulean"
 game "gta5"

--- a/ND_CharacterSelection/source/client.lua
+++ b/ND_CharacterSelection/source/client.lua
@@ -62,14 +62,19 @@ function SetDisplay(bool, typeName, bg, characters)
     end
 end
 
+started = false
+
 function start(switch)
     TriggerServerEvent("ND:GetCharacters")
-    TriggerServerEvent("ND_CharacterSelection:checkPerms")
     if switch then
         local ped = PlayerPedId()
         SwitchOutPlayer(ped, 0, 1)
         FreezeEntityPosition(ped, true)
         SetEntityVisible(ped, false, 0)
+        if not started then
+            TriggerServerEvent("ND_CharacterSelection:checkPerms")
+            started = true
+        end
     end
     if config.characterSelectionAopDisplay then
         SendNUIMessage({


### PR DESCRIPTION
Some users were experiencing issues with departments duplicating in game when attempting to edit/create characters.
The start function is being called more than once, a variable has been created to ensure that the checkPerms event is only triggered once. 

There's probably a slightly more efficient way to fix this issue however I don't fancy backtracking the code to prevent breaking changes.